### PR TITLE
Fixes: https://github.com/TimVanMourik/GiraffeTools/issues/35

### DIFF
--- a/app/porcupine/js/content.js
+++ b/app/porcupine/js/content.js
@@ -4,9 +4,9 @@ import TouchBackend from 'react-dnd-touch-backend'
 import HTML5Backend from 'react-dnd-html5-backend'
 import { default as ItemPreview } from './itemPreview';
 import Sidebar from './sidebar';
-import Canvas from './canvas'
+import Canvas from './canvas';
 import nodes from '../static/assets/nipype.json';
-// import zoomFunctions from './zoomFunctions';
+import ParameterPane from './parameterPane';
 import $ from 'jquery';
 
 require('browsernizr/test/touchevents');
@@ -28,6 +28,9 @@ class Content extends React.Component {
     this.changeSelectedNode = this.changeSelectedNode.bind(this);
     this.toggleSidebar      = this.toggleSidebar.bind(this);
     this.loadFromJson       = this.loadFromJson.bind(this);
+    this.modifyNodeParams   = this.modifyNodeParams.bind(this);
+    this.deleteNode         = this.deleteNode.bind(this);
+
   }; //end constructor
 
   componentWillMount() {
@@ -106,6 +109,21 @@ class Content extends React.Component {
     });
   }
 
+  modifyNodeParams(node, nodeId = this.state.selectedNode) {
+    const net = this.state.net;
+    net[nodeId] = node;
+    this.setState({ net });
+  }
+
+  deleteNode(nodeId) {
+    const net = this.state.net;
+    delete net[nodeId];
+    this.setState({
+      net: net,
+      selectedNode: null
+    });
+  }
+
   render() {
     return (
     <DragDropContextProvider backend={ Modernizr.touchevents ? TouchBackend : HTML5Backend }>
@@ -119,7 +137,13 @@ class Content extends React.Component {
             addNewNode          = {this.addNewNode}
             changeSelectedNode  = {this.changeSelectedNode}
           />
-          {/* SetParams */}
+          <ParameterPane
+            net                 = {this.state.net}
+            selectedNode        = {this.state.selectedNode}
+            deleteNode          = {this.deleteNode}
+            modifyNode          = {this.modifyNodeParams}
+            changeSelectedNode  = {this.changeSelectedNode}
+          />
           {/* Tooltip */}
           {/* Modal */}
         </div>

--- a/app/porcupine/js/field.js
+++ b/app/porcupine/js/field.js
@@ -1,0 +1,114 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+class Field extends React.Component {
+  constructor(props) {
+    super(props);
+    this.change = this.change.bind(this);
+  }
+  change(e) {
+    if (this.props.data.type === 'checkbox') {
+      this.props.changeField(this.props.id, e.target.checked);
+    } else if(this.props.data.type === 'number') {
+      this.props.changeField(this.props.id, Number(e.target.value));
+    } else {
+      this.props.changeField(this.props.id, e.target.value);
+    }
+  }
+  render() {
+    const type = this.props.data.type;
+    let inputElement;
+
+    if (type === 'text') {
+      inputElement = (
+        <input
+          type="text"
+          disabled={this.props.disabled}
+          value={this.props.value}
+          className="form-control"
+          id={this.props.id}
+          onChange={this.change}
+        />
+      );
+    } else if (type === 'number') {
+      inputElement = (
+        <input
+          type="number"
+          value={this.props.value}
+          disabled={this.props.disabled}
+          className="form-control"
+          id={this.props.id}
+          onChange={this.change}
+        />
+      );
+    } else if (type === 'float') {
+      inputElement = (
+        <input
+          type="number"
+          step="0.01"
+          disabled={this.props.disabled}
+          value={this.props.value}
+          className="form-control"
+          id={this.props.id}
+          onChange={this.change}
+        />
+      );
+    } else if (type === 'select') {
+      const options = [];
+      this.props.data.options.forEach(i => {
+        options.push(<option key={i} value={i}>{i}</option>);
+      });
+      inputElement = (
+        <select
+          value={this.props.value}
+          id={this.props.id}
+          disabled={this.props.disabled}
+          className="form-control"
+          onChange={this.change}
+        >
+          {options}
+        </select>
+      );
+    } else if (type === 'checkbox') {
+      inputElement = (
+        <div className="paramsCheckbox">
+          <input
+            type="checkbox"
+            disabled={this.props.disabled}
+            checked={this.props.value}
+            id={this.props.id}
+            onChange={this.change}
+          />
+          <label htmlFor={this.props.id}></label>
+        </div>
+      );
+    }
+    let displayStyle = "inherit";
+    if (inputElement.props.className == 'paramsCheckbox'){
+      displayStyle = "flex";
+    }
+    return (
+      <div style={{display: displayStyle}}>
+        <label htmlFor={this.props.id} className="sidebar-heading" style={{fontSize:"0.85em"}}>
+          {this.props.data.name.toUpperCase()}
+        </label>
+           {inputElement}
+      <br/>
+      </div>
+    );
+  }
+}
+
+Field.propTypes = {
+  id: PropTypes.string.isRequired,
+  data: PropTypes.object,
+  changeField: PropTypes.func,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.bool
+  ]),
+  disabled: PropTypes.bool
+};
+
+export default Field;

--- a/app/porcupine/js/parameterPane.js
+++ b/app/porcupine/js/parameterPane.js
@@ -1,0 +1,98 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import Field from './field';
+
+class ParameterPane extends React.Component {
+  constructor(props) {
+    super(props);
+    this.changeParams = this.changeParams.bind(this);
+    this.close = this.close.bind(this);
+    this.handleKeyPress = this.handleKeyPress.bind(this);
+  }
+  changeParams(prop, value) {
+    const net = this.props.net;
+    let node = net[this.props.selectedNode];
+    node = JSON.parse(JSON.stringify(node));
+    node.props[prop] = value;
+    this.props.modifyNode(node);
+  }
+  close() {
+    this.props.changeSelectedNode(null);
+  }
+  handleKeyPress(event) {
+    if (event.key == 'Delete') {
+      this.props.deleteNode(this.props.selectedNode);
+    }
+  }
+  componentDidMount() {
+    document.addEventListener("keydown", this.handleKeyPress, false);
+  }
+  componentWillUnmount() {
+    document.removeEventListener("keydown", this.handleKeyPress, false);
+  }
+  render() {
+    if (this.props.selectedNode) {
+      const params = [];
+      const props = [];
+      const node = this.props.net[this.props.selectedNode];
+
+      Object.keys(node.ports).forEach(i => {
+        const port = node.ports[i];
+        const data = { name: port.name, type: 'text' };
+        params.push(
+          <Field
+            id={port.name}
+            key={i}
+            data={data}
+            disabled={false}
+            changeField={this.changeParams}
+          />
+        );
+      });
+
+      return (
+        <div className="setparams setparamsActive" >
+          <div className="setHead">
+            <h5 className="sidebar-heading">NODE SELECTED</h5>
+            <h4>{node.title.name}</h4>
+            <span className="glyphicon glyphicon-remove-sign closeSign" onClick={() => this.close()} aria-hidden="true"></span>
+          </div>
+          <div className="setContain">
+            <form className="form-horizontal">
+              {params}
+            </form>
+            <br />
+            <button
+              type="button"
+              className="btn btn-block deleteLayerButton sidebar-heading"
+              onClick={() => this.props.deleteNode(this.props.selectedNode)}
+            >
+              DELETE NODE
+            </button>
+          </div>
+        </div>
+      );
+    } else {
+      return (
+        <div className="col-md-3 setparams" >
+          <div className="setHead" style={{ color: 'white' }}>
+            Settings
+          </div>
+          <div style={{ padding: '30px' }}>
+            select a node to set its parameters
+          </div>
+        </div>
+      );
+    }
+  }
+}
+
+ParameterPane.propTypes = {
+  selectedNode: PropTypes.string,
+  net: PropTypes.object,
+  deleteNode: PropTypes.func,
+  modifyNode: PropTypes.func,
+  changeSelectedNode: PropTypes.func
+};
+
+export default ParameterPane;


### PR DESCRIPTION
Show a parameter pane, on clicking on a node

## Description
- [x] Copying in the useful bits of the parameter pane. (/fabrik/js/setParams.js), but please call it parameterPane.js instead
   - [x] Please rename fabrik's concept of 'layer' to 'node'
   - [x] In the fabrik code, you may find some train/test structure. It's irrelevant, so remove it.
- [ ] The parameter pane will set parameters for the node. The way in which this is stored needs to be coordinated with #37.
- [x] All parameters can be strings, for the moment.
- [ ] Stretch goal, only implement if the rest is not too difficult: for each parameter give it a checkbox for 'visible' that allows ports to hide/show it from the node in the editor.

## Related Issue
#35 

## Motivation and Context
Fabrik

## How Has This Been Tested?
Local

## Screenshots (if appropriate):
![screenshot from 2018-05-09 14-54-25](https://user-images.githubusercontent.com/4920000/39802722-fe3dcc26-5398-11e8-973e-9e523e7bea16.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
