### PR TITLE
makes nodes unselectable

### DIFF
--- a/app/porcupine/static/css/porcupine.css
+++ b/app/porcupine/static/css/porcupine.css
@@ -415,6 +415,7 @@ body {
   background: #e15e4f;
   color: white;
   cursor: pointer;
+  user-select: none;
 }
 
 .node.preview{


### PR DESCRIPTION
## Description
Makes nodes unselectable.

## Related Issue
#25 

## Motivation and Context
On touch devices text was getting selected instead of node getting dragged.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)