### PR TITLE
Fixes: https://github.com/TimVanMourik/GiraffeTools/issues/33

### DIFF
--- a/app/porcupine/js/canvas.js
+++ b/app/porcupine/js/canvas.js
@@ -170,20 +170,20 @@ class Canvas extends React.Component {
         >
           {nodes}
         </div>
-        {/*
+        
         <div id='icon-plus' className="canvas-icon">
-          <p>Press ]</p>
+          <p>Press</p>
           <button className="btn btn-default text-center">
-              <span className="glyphicon glyphicon glyphicon-plus" aria-hidden="true"></span>
+              <span aria-hidden="true">+</span>
           </button>
         </div>
         <div id='icon-minus' className="canvas-icon">
-          <p>Press [</p>
+          <p>Press</p>
           <button className="btn btn-default text-center">
-              <span className="glyphicon glyphicon glyphicon-minus" aria-hidden="true"></span>
+              <span aria-hidden="true">-</span>
           </button>
         </div>
-        <div style={{ ...style, backgroundColor }}>
+        {/* <div style={{ ...style, backgroundColor }}>
           {isActive ? 'Release to drop' : 'Drag a box here'}
         </div>
          */}

--- a/app/porcupine/js/content.js
+++ b/app/porcupine/js/content.js
@@ -6,7 +6,7 @@ import { default as ItemPreview } from './itemPreview';
 import Sidebar from './sidebar';
 import Canvas from './canvas'
 import nodes from '../static/assets/nipype.json';
-// import zoomFunctions from './zoomFunctions';
+import zoomFunctions from './zoomFunctions';
 import $ from 'jquery';
 
 require('browsernizr/test/touchevents');
@@ -90,15 +90,15 @@ class Content extends React.Component {
       newNode.colour = currentNodes.colour;
       newNode.info = { category, name };
       newNode.state = {
-        //This translation definitely needs to be fixed
-        x: (node['position'][0] - canvas.x)/zoom - 45 + 1000,
-        y: (node['position'][1] - canvas.y)/zoom - 25 + 400,
+        x: node['position'][0],
+        y: node['position'][1],
         class: ''
       };
       newNode.links = { input: [], output: [] };
 
       this.addNewNode(newNode);
     });
+    zoomFunctions().onLoaded();
 
     // load links
     json['links'].forEach(link => {

--- a/app/porcupine/js/zoomFunctions.js
+++ b/app/porcupine/js/zoomFunctions.js
@@ -1,14 +1,16 @@
-export default function() {
+export default function () {
   "use strict";
 
   let zoomFunctions = document.getElementById('zoomContainer');
-  let canvas        = document.getElementById('jsplumbContainer');
+  let canvas = document.getElementById('jsplumbContainer');
+  let zoomIn = document.getElementById('icon-plus');
+  let zoomOut = document.getElementById('icon-minus');
 
   if (!canvas) { return; }
 
   let params = {
-    x:    getQueryVariable('x'),
-    y:    getQueryVariable('y'),
+    x: getQueryVariable('x'),
+    y: getQueryVariable('y'),
     zoom: getQueryVariable('zoom')
   };
 
@@ -17,49 +19,49 @@ export default function() {
   current.y = params.y ? parseFloat(params.y) : $(canvas).data('y');
   current.zoom = params.zoom ? parseFloat(params.zoom) : $(canvas).data('zoom');
 
-  canvas.x      = 0;
-  canvas.y      = 0;
-  canvas.scale  = 1;
-  canvas.updateContainerPosition = function() {
+  canvas.x = 0;
+  canvas.y = 0;
+  canvas.scale = 1;
+  canvas.updateContainerPosition = function () {
     canvas.style.left = canvas.x + 'px';
-    canvas.style.top  = canvas.y + 'px';
+    canvas.style.top = canvas.y + 'px';
   };
-  canvas.updateContainerScale = function() {
-    canvas.style.transform = 'scale('+canvas.scale+')'
+  canvas.updateContainerScale = function () {
+    canvas.style.transform = 'scale(' + canvas.scale + ')'
   };
 
   canvas.updateContainerPosition();
   canvas.updateContainerScale();
 
-  zoomFunctions.addEventListener('gestureend', function(e) {
-      if (e.scale < 1.0) {
-          onZoom(current.zoom * 1.2);
-      } else if (e.scale > 1.0) {
-          onZoom(current.zoom / 1.2);
-      }
+  zoomFunctions.addEventListener('gestureend', function (e) {
+    if (e.scale < 1.0) {
+      onZoom(current.zoom * 1.2);
+    } else if (e.scale > 1.0) {
+      onZoom(current.zoom / 1.2);
+    }
   }, false);
 
   let dragging = false;
   let state = { click: false, pan: false };
   let previousMousePosition;
 
-  zoomFunctions.onmousedown = function(e) {
+  zoomFunctions.onmousedown = function (e) {
     e.preventDefault();
     dragging = true;
     state.click = true;
     previousMousePosition = { x: e.pageX, y: e.pageY };
   };
 
-  window.onmouseup = function() {
+  window.onmouseup = function () {
     dragging = false;
   };
 
-  zoomFunctions.ondragstart = function(e) {
+  zoomFunctions.ondragstart = function (e) {
     e.preventDefault();
   };
 
-  zoomFunctions.onmousemove = function(e) {
-    if(state.click){
+  zoomFunctions.onmousemove = function (e) {
+    if (state.click) {
       state.pan = true;
     }
     if (dragging) {
@@ -71,15 +73,56 @@ export default function() {
     }
   };
 
-  zoomFunctions.ondblclick = function(e) {
+  zoomFunctions.ondblclick = function (e) {
     e.preventDefault();
     onZoom((e.ctrlKey) ? current.zoom * 1.2 : current.zoom / 1.2);
   };
 
+  window.onkeypress = function (e) {
+    if (e.key == '-') {
+      onZoom(current.zoom * 1.2);
+    }
+    else if (e.key == '=') {
+      onZoom(current.zoom / 1.2);
+    }
+  }
+
+  zoomOut.onclick = function () {
+    onZoom(current.zoom * 1.2);
+  };
+
+  zoomIn.onclick = function () {
+    onZoom(current.zoom / 1.2);
+  };
+
+  state.onLoaded = function () {
+    let minX = Number.MAX_SAFE_INTEGER,
+      minY = Number.MAX_SAFE_INTEGER,
+      maxX = Number.MIN_SAFE_INTEGER,
+      maxY = Number.MIN_SAFE_INTEGER;
+
+    for (let i = 0; i < canvas.childNodes.length; ++i) {
+      const node = canvas.childNodes[i];
+      const x = parseInt(node.style.left);
+      const y = parseInt(node.style.top);
+      if (minX > x) minX = x;
+      if (minY > y) minY = y;
+      if (maxX < x + node.offsetWidth) maxX = x + node.offsetWidth;
+      if (maxY < y + node.offsetHeight) maxY = y + node.offsetHeight;
+    }
+
+    const scaleX = zoomFunctions.offsetWidth / (maxX - minX + 25);
+    const scaleY = zoomFunctions.offsetHeight / (maxY - minY + 25);
+    const scale = Math.min(scaleX, scaleY);
+    canvas.x = 0 - minX;
+    canvas.y = 0 - minY;
+    onZoom(1 / scale);
+  }
+
   function onZoom(zoom) {
     canvas.scale = 1 / zoom;
-    canvas.x = 0 - 105 * (canvas.scale * canvas.scale);
-    canvas.y = 0 - 15  * (canvas.scale * canvas.scale);
+    canvas.x = canvas.x * current.zoom * canvas.scale;
+    canvas.y = canvas.y * current.zoom * canvas.scale;
     canvas.style.transitionDuration = "0.1s";
     canvas.updateContainerPosition();
     canvas.updateContainerScale();
@@ -95,7 +138,7 @@ export default function() {
         return p[1];
       }
     }
-    return(false);
+    return (false);
   }
 
   return state;


### PR DESCRIPTION
## Description
Pretty zoom functionality in Porcupine

## Related Issue
Fix: #33 

## Motivation and Context
- [x] Introduce zoom buttons to porcupine, equivalent (not necessarily identical) to fabrik's.
  - [x] They need to be pressable
  - [x] They need to respond to + and - key presses
- [x] When a workflow is loaded, adjust the zoom level. At this moment, the nodes are shifted in an ugly hard-coded manner (content.js:93:95) to make it fit within the displayed canvas. Instead, make this dynamic:
  - [x] remove the (content.js:93:95) shift
  - [x] after the node loading section, adjust the canvas zoom and its translation to fit all the nodes
you can try this out with this link, or rather its localhost:8000 version of it.
- [ ] Stretch goal, for if the above changes are trivial: add < > ^ v buttons to the sides to make it easier to move through the canvas.

## How Has This Been Tested?
Test local http://localhost:8000/gh/Timvanmourik/somegiraffeexample/master/porcupine

## Screenshots (if appropriate):
![screenshot from 2018-05-10 16-47-44](https://user-images.githubusercontent.com/4920000/39863887-26ead3c4-5472-11e8-987a-de7d13b496da.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
