### PR TITLE
[React] Hover event on node, provide a tooltip

### DIFF
--- a/app/porcupine/js/canvas.js
+++ b/app/porcupine/js/canvas.js
@@ -28,7 +28,6 @@ class Canvas extends React.Component {
     this.hoverNodeEvent       = this.hoverNodeEvent.bind(this);
     this.leaveNodeEvent       = this.leaveNodeEvent.bind(this);
     this.clickOrDraggedNode   = false;
-    this.hover = 0;
   }
 
   componentDidMount() {
@@ -62,11 +61,7 @@ class Canvas extends React.Component {
   }
 
   hoverNodeEvent(event, nodeId) {
-    if (this.hover === 0) {
-      this.props.changeHoveredNode(nodeId);
-    } else if (this.hover === 1) {
-      this.hover = 0;
-    }
+    this.props.changeHoveredNode(nodeId);
     event.stopPropagation();
   }
 

--- a/app/porcupine/js/canvas.js
+++ b/app/porcupine/js/canvas.js
@@ -214,9 +214,9 @@ Canvas.propTypes = {
   addNewNode:           PropTypes.func.isRequired,
   changeSelectedNode:   PropTypes.func.isRequired,
   changeHoveredNode:    PropTypes.func.isRequired,
-	connectDropTarget: 		PropTypes.func.isRequired,
-	isOver: 							PropTypes.bool.isRequired,
-	canDrop: 							PropTypes.bool.isRequired,
+  connectDropTarget:    PropTypes.func.isRequired,
+  isOver: 		PropTypes.bool.isRequired,
+  canDrop: 		PropTypes.bool.isRequired,
 };
 
 export default DropTarget(ItemTypes.BOX, boxTarget, (connect, monitor) => ({

--- a/app/porcupine/js/canvas.js
+++ b/app/porcupine/js/canvas.js
@@ -26,6 +26,7 @@ class Canvas extends React.Component {
     this.clickOrDraggedNode   = false;
     this.clickNodeEvent       = this.clickNodeEvent.bind(this);
     this.hoverNodeEvent       = this.hoverNodeEvent.bind(this);
+    this.leaveNodeEvent       = this.leaveNodeEvent.bind(this);
     this.clickOrDraggedNode   = false;
     this.hover = 0;
   }
@@ -66,6 +67,11 @@ class Canvas extends React.Component {
     } else if (this.hover === 1) {
       this.hover = 0;
     }
+    event.stopPropagation();
+  }
+
+  leaveNodeEvent(event){
+    this.props.changeHoveredNode(null);
     event.stopPropagation();
   }
 
@@ -163,6 +169,7 @@ class Canvas extends React.Component {
           ports  = {node.ports}
           click  = {this.clickNodeEvent}
           hover  = {this.hoverNodeEvent}
+          leave  = {this.leaveNodeEvent}
         />
       );
     })

--- a/app/porcupine/js/canvas.js
+++ b/app/porcupine/js/canvas.js
@@ -25,7 +25,9 @@ class Canvas extends React.Component {
     this.clickCanvas          = this.clickCanvas.bind(this);
     this.clickOrDraggedNode   = false;
     this.clickNodeEvent       = this.clickNodeEvent.bind(this);
+    this.hoverNodeEvent       = this.hoverNodeEvent.bind(this);
     this.clickOrDraggedNode   = false;
+    this.hover = 0;
   }
 
   componentDidMount() {
@@ -54,6 +56,15 @@ class Canvas extends React.Component {
       this.props.changeSelectedNode(nodeId);
     } else if (this.clickOrDraggedNode === true) {
       this.clickOrDraggedNode = false;
+    }
+    event.stopPropagation();
+  }
+
+  hoverNodeEvent(event, nodeId) {
+    if (this.hover === 0) {
+      this.props.changeHoveredNode(nodeId);
+    } else if (this.hover === 1) {
+      this.hover = 0;
     }
     event.stopPropagation();
   }
@@ -151,6 +162,7 @@ class Canvas extends React.Component {
           colour = {node.colour}
           ports  = {node.ports}
           click  = {this.clickNodeEvent}
+          hover  = {this.hoverNodeEvent}
         />
       );
     })
@@ -199,6 +211,7 @@ Canvas.propTypes = {
   net:                  PropTypes.object.isRequired,
   addNewNode:           PropTypes.func.isRequired,
   changeSelectedNode:   PropTypes.func.isRequired,
+  changeHoveredNode:    PropTypes.func.isRequired,
 	connectDropTarget: 		PropTypes.func.isRequired,
 	isOver: 							PropTypes.bool.isRequired,
 	canDrop: 							PropTypes.bool.isRequired,

--- a/app/porcupine/js/content.js
+++ b/app/porcupine/js/content.js
@@ -8,6 +8,7 @@ import Canvas from './canvas';
 import nodes from '../static/assets/nipype.json';
 import ParameterPane from './parameterPane';
 import zoomFunctions from './zoomFunctions';
+import Tooltip from './tooltip';
 import $ from 'jquery';
 
 require('browsernizr/test/touchevents');
@@ -31,6 +32,7 @@ class Content extends React.Component {
     this.loadFromJson       = this.loadFromJson.bind(this);
     this.modifyNodeParams   = this.modifyNodeParams.bind(this);
     this.deleteNode         = this.deleteNode.bind(this);
+    this.changeHoveredNode = this.changeHoveredNode.bind(this);
 
   }; //end constructor
 
@@ -62,6 +64,20 @@ class Content extends React.Component {
     this.setState({
       net,
       selectedNode: nodeId
+    });
+  }
+
+  changeHoveredNode(nodeId) {
+    const net = this.state.net;
+    if (this.state.hoveredNode && this.state.hoveredNode in net) {
+      net[this.state.hoveredNode].info.class = '';
+    }
+    if (nodeId) {
+      net[nodeId].info.class = 'hover';
+    }
+    this.setState({ 
+      net,
+      hoveredNode: nodeId
     });
   }
 
@@ -147,7 +163,11 @@ class Content extends React.Component {
             modifyNode          = {this.modifyNodeParams}
             changeSelectedNode  = {this.changeSelectedNode}
           />
-          {/* Tooltip */}
+          <Tooltip
+            id={'tooltip_text'}
+            net={this.state.net}
+            hoveredNode={this.state.hoveredNode}
+          />
           {/* Modal */}
         </div>
         { Modernizr.touchevents && <ItemPreview key="__preview" name="Item" /> }

--- a/app/porcupine/js/content.js
+++ b/app/porcupine/js/content.js
@@ -138,6 +138,7 @@ class Content extends React.Component {
             nextNodeId          = {this.state.nextNodeId}
             addNewNode          = {this.addNewNode}
             changeSelectedNode  = {this.changeSelectedNode}
+            changeHoveredNode   = {this.changeHoveredNode}
           />
           <ParameterPane
             net                 = {this.state.net}

--- a/app/porcupine/js/node.js
+++ b/app/porcupine/js/node.js
@@ -19,6 +19,8 @@ class Node extends React.Component {
         }}
         onClick={(event) => click(event, id)}
         onMouseEnter={(event) => hover(event, id)}
+        data-tip='tooltip'
+        data-for='getContent'
       >
         <div className="node__type">
           {type}

--- a/app/porcupine/js/node.js
+++ b/app/porcupine/js/node.js
@@ -7,7 +7,7 @@ class Node extends React.Component {
   }
 
   render() {
-    const { x, y, colour, class: classname, id, type, click, ports, hover } = this.props;
+    const { x, y, colour, class: classname, id, type, click, ports, hover, leave } = this.props;
     const visiblePorts = ports.filter(port => port.visible);
     return (
       <div
@@ -19,6 +19,7 @@ class Node extends React.Component {
         }}
         onClick={(event) => click(event, id)}
         onMouseEnter={(event) => hover(event, id)}
+        onMouseLeave={(event) => leave(event)}
         data-tip='tooltip'
         data-for='getContent'
       >
@@ -64,6 +65,7 @@ Node.propTypes = {
   y:      PropTypes.number.isRequired,
   click:  PropTypes.func.isRequired,
   hover:  PropTypes.func.isRequired,
+  leave:    PropTypes.func.isRequired,
   class:  PropTypes.string,
   ports: PropTypes.array.isRequired
 }

--- a/app/porcupine/js/node.js
+++ b/app/porcupine/js/node.js
@@ -66,9 +66,9 @@ Node.propTypes = {
   y:      PropTypes.number.isRequired,
   click:  PropTypes.func.isRequired,
   hover:  PropTypes.func.isRequired,
-  leave:    PropTypes.func.isRequired,
+  leave:  PropTypes.func.isRequired,
   class:  PropTypes.string,
-  ports: PropTypes.array.isRequired
+  ports:  PropTypes.array.isRequired
 }
 
 export default Node;

--- a/app/porcupine/js/node.js
+++ b/app/porcupine/js/node.js
@@ -7,7 +7,7 @@ class Node extends React.Component {
   }
 
   render() {
-    const { x, y, colour, class: classname, id, type, click, ports } = this.props;
+    const { x, y, colour, class: classname, id, type, click, ports, hover } = this.props;
     const visiblePorts = ports.filter(port => port.visible);
     return (
       <div
@@ -18,7 +18,7 @@ class Node extends React.Component {
           background: colour
         }}
         onClick={(event) => click(event, id)}
-        onTouchEnd={(event) => click(event, id)}
+        onMouseEnter={(event) => hover(event, id)}
       >
         <div className="node__type">
           {type}
@@ -61,6 +61,7 @@ Node.propTypes = {
   x:      PropTypes.number.isRequired,
   y:      PropTypes.number.isRequired,
   click:  PropTypes.func.isRequired,
+  hover:  PropTypes.func.isRequired,
   class:  PropTypes.string,
   ports: PropTypes.array.isRequired
 }

--- a/app/porcupine/js/node.js
+++ b/app/porcupine/js/node.js
@@ -18,6 +18,7 @@ class Node extends React.Component {
           background: colour
         }}
         onClick={(event) => click(event, id)}
+        onTouchEnd={(event) => click(event, id)}
         onMouseEnter={(event) => hover(event, id)}
         onMouseLeave={(event) => leave(event)}
         data-tip='tooltip'

--- a/app/porcupine/js/tooltip.js
+++ b/app/porcupine/js/tooltip.js
@@ -11,10 +11,11 @@ class Tooltip extends React.Component {
     render() {
         if (this.props.hoveredNode && this.props.hoveredNode in this.props.net) {
           const params = [];
-          const node = this.props.net[this.props.hoveredNode];
+          let nodePorts = this.props.net[this.props.hoveredNode].ports;
+          if (nodePorts.length > 10){ nodePorts = nodePorts.filter(port => port.value)}
 
-          Object.keys(node.ports).forEach(i => {
-            const port = node.ports[i];
+          Object.keys(nodePorts).forEach(i => {
+            const port = nodePorts[i];
             params.push(
             <TooltipData
               id={port.name}

--- a/app/porcupine/js/tooltip.js
+++ b/app/porcupine/js/tooltip.js
@@ -9,24 +9,24 @@ class Tooltip extends React.Component {
     }
 
     render() {
-        if (this.props.hoveredNode && this.state.hoveredNode in net) {
+        if (this.props.hoveredNode && this.props.hoveredNode in this.props.net) {
           const params = [];
           const node = this.props.net[this.props.hoveredNode];
 
           Object.keys(node.ports).forEach(i => {
             const port = node.ports[i];
             params.push(
-              <TooltipData
-                id={port.name}
-                key={port.name}
-                data={{ name: port.name, type: 'text', label: port.name }}
-                value={port.value}
-                disabled={false}
-                changeField={this.changeParams}
-              />
-            );
+            <TooltipData
+              id={port.name}
+              key={port.name}
+              data={{ name: port.name, type: 'text', label: port.name }}
+              value={port.value}
+              disabled={false}
+              changeField={this.changeParams}
+            />
+           );
           });
-        
+
           return (
             <ReactTooltip multiline={true} id='getContent' effect='solid' place='right' className='customTooltip'>
               <div style={{display: 'inline-grid'}}>
@@ -34,7 +34,8 @@ class Tooltip extends React.Component {
               </div>
             </ReactTooltip>
           )
-        }
+       }
+       else return <div></div>;
     }
 }
 
@@ -42,5 +43,5 @@ Tooltip.propTypes = {
     hoveredNode: PropTypes.string,
     net: PropTypes.object,
 };
-  
+
 export default Tooltip;

--- a/app/porcupine/js/tooltip.js
+++ b/app/porcupine/js/tooltip.js
@@ -20,7 +20,7 @@ class Tooltip extends React.Component {
             <TooltipData
               id={port.name}
               key={port.name}
-              data={{ name: port.name, type: 'text', label: port.name }}
+              data={{ name: port.name, type: port.type }}
               value={port.value}
               disabled={false}
               changeField={this.changeParams}

--- a/app/porcupine/js/tooltip.js
+++ b/app/porcupine/js/tooltip.js
@@ -1,0 +1,46 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import TooltipData from './tooltipData';
+import ReactTooltip from 'react-tooltip';
+
+class Tooltip extends React.Component {
+    constructor(props) {
+      super(props);
+    }
+
+    render() {
+        if (this.props.hoveredNode && this.state.hoveredNode in net) {
+          const params = [];
+          const node = this.props.net[this.props.hoveredNode];
+
+          Object.keys(node.ports).forEach(i => {
+            const port = node.ports[i];
+            params.push(
+              <TooltipData
+                id={port.name}
+                key={port.name}
+                data={{ name: port.name, type: 'text', label: port.name }}
+                value={port.value}
+                disabled={false}
+                changeField={this.changeParams}
+              />
+            );
+          });
+        
+          return (
+            <ReactTooltip multiline={true} id='getContent' effect='solid' place='right' className='customTooltip'>
+              <div style={{display: 'inline-grid'}}>
+                {params}
+              </div>
+            </ReactTooltip>
+          )
+        }
+    }
+}
+
+Tooltip.propTypes = {
+    hoveredNode: PropTypes.string,
+    net: PropTypes.object,
+};
+  
+export default Tooltip;

--- a/app/porcupine/js/tooltipData.js
+++ b/app/porcupine/js/tooltipData.js
@@ -9,11 +9,11 @@ class tooltipData extends React.Component {
     change(e) {
         const type = this.props.data.type
         if (type === 'checkbox') {
-          this.props.changeField(this.props.id, e.target.checked);
+          this.props.changeField(e.target.checked);
         } else if (type === 'number') {
-          this.props.changeField(this.props.id, Number(e.target.value));
+          this.props.changeField(Number(e.target.value));
         } else {
-          this.props.changeField(this.props.id, e.target.value);
+          this.props.changeField(e.target.value);
         }
     }
     render() {

--- a/app/porcupine/js/tooltipData.js
+++ b/app/porcupine/js/tooltipData.js
@@ -1,0 +1,50 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+class tooltipData extends React.Component {
+    constructor(props) {
+        super(props);
+        this.change = this.change.bind(this);
+      }
+    change(e) {
+        const type = this.props.data.type
+        if (type === 'checkbox') {
+          this.props.changeField(this.props.id, e.target.checked);
+        } else if (type === 'number') {
+          this.props.changeField(this.props.id, Number(e.target.value));
+        } else {
+          this.props.changeField(this.props.id, e.target.value);
+        }
+    }
+    render() {
+        const type = this.props.data.type;
+        let inputElement;
+        if (type === 'checkbox'){
+            inputElement = this.props.value ? 'True' : 'False';
+        } else{
+            inputElement = this.props.value;
+        }
+
+        return (
+            <div className="tooltipData">
+              <p className="tooltipLabel">{this.props.data.name}:</p>
+              <p className="tooltipField">{inputElement}</p>
+            </div>
+        );
+    }
+}
+
+tooltipData.propTypes = {
+    id: PropTypes.string.isRequired,
+    data: PropTypes.object,
+    changeField: PropTypes.func,
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.bool
+    ]),
+    disabled: PropTypes.bool
+  };
+  
+export default tooltipData;
+  


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
 
- Hovering on a node shows a tooltip with all parameters and their current values
- When a node has more than 10 parameters the tooltip only shows defined ones.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Refers to #34 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
#34 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally.
## Screenshots (if appropriate):
![porcupinescreen](https://user-images.githubusercontent.com/17225103/40585216-442ca1f4-619e-11e8-8fcb-aa993b9a5e04.png)

when there are more than 10 parameters:

![porcupine2 2](https://user-images.githubusercontent.com/17225103/40585220-55b2a734-619e-11e8-8ba2-36539449b0d7.PNG)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
