### PR TITLE
fix to issue #54: Codecov doesn't work anymore since pytest update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ webpack-stats.json
 .idea
 
 app/fabrik/static/js/fabrik.js
+
+code-coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - python manage.py collectstatic --noinput -i other
   - python manage.py migrate
 script:
-  - python manage.py test
+  - coverage run ./manage.py test --noinput --settings=app.settings.local
   - cd ..; npm test
 after_success:
   - pip install codecov

--- a/package-lock.json
+++ b/package-lock.json
@@ -369,6 +369,12 @@
         "sprintf-js": "1.0.3"
       }
     },
+    "argv": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
+      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
+      "dev": true
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -2151,6 +2157,17 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
+    },
+    "codecov": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.0.2.tgz",
+      "integrity": "sha512-9ljtIROIjPIUmMRqO+XuDITDoV8xRrZmA0jcEq6p2hg2+wY9wGmLfreAZGIL72IzUfdEDZaU8+Vjidg1fBQ8GQ==",
+      "dev": true,
+      "requires": {
+        "argv": "0.0.2",
+        "request": "2.85.0",
+        "urlgrey": "0.4.4"
+      }
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -10615,6 +10632,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
+      "dev": true
+    },
+    "urlgrey": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
+      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
       "dev": true
     },
     "use": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "babel-preset-react": "^6.5.0",
     "bootstrap": "^4.1.1",
     "browsernizr": "^2.2.0",
+    "codecov": "^3.0.2",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.3.3",
@@ -56,6 +57,8 @@
     ],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
-    ]
+    ],
+    "coverageDirectory": "./code-coverage/",
+    "collectCoverage": true
   }
 }


### PR DESCRIPTION
Switching from `pytest` to `python manage.py test` was not generating the `.coverage` file
Updating the commands seems to have solved the issue.

## Description
Changed `python manage.py test` to `coverage run ./manage.py test --noinput --settings=app.settings.local`

## Related Issue
https://github.com/TimVanMourik/GiraffeTools/issues/54

## How Has This Been Tested?
I have checked that `.coverage` file is getting generated upon running the tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
