### PR TITLE
Fix: the nodes are not clickable on mobile/tablet

### DIFF
--- a/app/porcupine/js/canvas.js
+++ b/app/porcupine/js/canvas.js
@@ -60,7 +60,7 @@ class Canvas extends React.Component {
 
   updateNodePosition(event) {
     if (!this.clickOrDraggedNode) {
-      this.clickOrDraggedNode = 1;
+      this.clickOrDraggedNode = true;
     }
     const nodeId = event.el.id;
     const node = this.props.net[node];

--- a/app/porcupine/js/node.js
+++ b/app/porcupine/js/node.js
@@ -18,6 +18,7 @@ class Node extends React.Component {
           background: colour
         }}
         onClick={(event) => click(event, id)}
+        onTouchEnd={(event) => click(event, id)}
       >
         <div className="node__type">
           {type}


### PR DESCRIPTION

## Description
The nodes are not clickable on mobile/tablet

## Related Issue
Ref: https://github.com/TimVanMourik/GiraffeTools/issues/35#issuecomment-390219747

## How Has This Been Tested?
Local

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
