### PR TITLE
fix to issue #54: Codecov doesn't work anymore since pytest update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ webpack-stats.json
 .idea
 
 app/fabrik/static/js/fabrik.js
+
+code-coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ script:
   - coverage run ./manage.py test --noinput --settings=app.settings.local
   - cd ..; npm test
 after_success:
-  - pip install codecov
-  - codecov
+  - bash <(curl -s https://codecov.io/bash) -cF python
+  - bash <(curl -s https://codecov.io/bash) -cF javascript

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,6 @@ script:
   - coverage run ./manage.py test --noinput --settings=app.settings.local
   - cd ..; npm test
 after_success:
-  - bash <(curl -s https://codecov.io/bash) -cF python
+  - pip install codecov
+  - codecov
   - bash <(curl -s https://codecov.io/bash) -cF javascript

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,4 @@ before_script:
   - python manage.py collectstatic --noinput -i other
   - python manage.py migrate
 script:
-  - coverage run ./manage.py test --noinput --settings=app.settings.local
-  - cd ..; npm test
-after_success:
-  - pip install codecov
-  - codecov
-  - bash <(curl -s https://codecov.io/bash) -cF javascript
+  - bash ./../bin/run-codecov.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - python manage.py collectstatic --noinput -i other
   - python manage.py migrate
 script:
-  - python manage.py test
+  - coverage run ./manage.py test --noinput --settings=app.settings.local
   - cd ..; npm test
 after_success:
   - pip install codecov

--- a/bin/run-codecov.sh
+++ b/bin/run-codecov.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-# python tests
-coverage run ./manage.py test --noinput --settings=app.settings.local
-bash <(curl -s https://codecov.io/bash) -cF python
-
 # javascript tests
 cd ..
 npm test
 bash <(curl -s https://codecov.io/bash) -cF javascript
+
+# python tests
+cd app
+coverage run ./manage.py test --noinput --settings=app.settings.local
+bash <(curl -s https://codecov.io/bash) -cF python
+

--- a/bin/run-codecov.sh
+++ b/bin/run-codecov.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# python tests
+coverage run ./manage.py test --noinput --settings=app.settings.local
+bash <(curl -s https://codecov.io/bash) -cF python
+
+# javascript tests
+cd ..
+npm test
+bash <(curl -s https://codecov.io/bash) -cF javascript

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "babel-preset-react": "^6.5.0",
     "bootstrap": "^4.1.1",
     "browsernizr": "^2.2.0",
+    "codecov": "^3.0.2",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.3.3",
@@ -56,6 +57,8 @@
     ],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
-    ]
+    ],
+    "coverageDirectory": "./code-coverage/",
+    "collectCoverage": true
   }
 }


### PR DESCRIPTION
Switching from `pytest` to `python manage.py test` was not generating the `.coverage` file
Updating the commands seems to have solved the issue.

## Description
Changed `python manage.py test` to `coverage run ./manage.py test --noinput --settings=app.settings.local`

## Related Issue
https://github.com/TimVanMourik/GiraffeTools/issues/54

## How Has This Been Tested?
I have checked that `.coverage` file is getting generated upon running the tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
