### PR TITLE
Persist cache across coala runs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,6 @@ services:
     working_dir: /code
     volumes:
       - .:/code
+      # this may not work on windows, need to think of a workaround
+      # this will speed up multiple runs by a LOT
+      - /tmp/coala:/cache


### PR DESCRIPTION
This speeds up consecutive runs, Windows …* might* need work around

Note that we should also add to the contributing guide that you should rerun coala until it passes with no errors.

Some related comments can be found in #68 